### PR TITLE
fix: Enable display of featured grants on topic pages

### DIFF
--- a/app/topics/nonprofit-funding/NonprofitFundingClient.tsx
+++ b/app/topics/nonprofit-funding/NonprofitFundingClient.tsx
@@ -83,7 +83,6 @@ export default function NonprofitFundingClient({ initialGrants, initialError }: 
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {/* 
             {isLoading ? (
               <p className="text-center text-muted-foreground py-10">Loading grants...</p>
             ) : error ? (

--- a/app/topics/small-business-grants/SmallBusinessGrantsClient.tsx
+++ b/app/topics/small-business-grants/SmallBusinessGrantsClient.tsx
@@ -82,7 +82,6 @@ export default function SmallBusinessGrantsClient({ initialGrants, initialError 
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {/* 
             {isLoading ? (
               <p className="text-center text-muted-foreground py-10">Loading grants...</p>
             ) : error ? (


### PR DESCRIPTION
Uncomments the GrantList rendering logic within the CardContent sections of `NonprofitFundingClient.tsx` and
`SmallBusinessGrantsClient.tsx`.

This allows the featured grants, fetched by the parent Server Components for these topic pages, to be displayed, along with appropriate loading, error, or empty state messages. This addresses the issue of these sections not appearing functional.